### PR TITLE
fix: Upgrade go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.18
         id: go
 
       - name: Check out code

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.18
         id: go
 
       - name: Check out code


### PR DESCRIPTION
This PR upgrades the version of go from `1.15^` to `1.18^` in order to fix this vulnerability:

> Go before 1.16.9 and 1.17.x before 1.17.2 has a Buffer Overflow via large arguments in a function invocation from a WASM module, when GOARCH=wasm GOOS=js is used.